### PR TITLE
remove systemd logic as it breaks the service

### DIFF
--- a/templates/systemd-override.erb
+++ b/templates/systemd-override.erb
@@ -1,8 +1,4 @@
-<% if @manage_package_repo and (scope.function_versioncmp([@version.to_s, '9.1']) >= 0) -%>
 .include /lib/systemd/system/postgresql-<%= @version %>.service
-<% else -%>
-.include /lib/systemd/system/postgresql.service
-<% end -%>
 [Service]
 Environment=PGPORT=<%= @port %>
 Environment=PGDATA=<%= @datadir %>


### PR DESCRIPTION
This is fixed in later versions of the postgresql module, but there are significant changes to the module which will require a non-trivial amount of testing/refactoring.

For now, we'll patch this file and maintain our own fork of 4.6.1 until that effort can be prioritized.

The problem is we want to turn off `manage_package_repo`, but the logic in this template will break the systemd service if doing so. Remove that logic completely.